### PR TITLE
feat(metrics): add Prometheus metrics for dispatch execution and HTTP exposure tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,20 @@ mgr, _ := dispatch.NewDispatchManager(
 ```
 
 The `MockPredictionEngine` returns deterministic values and is used in tests. Custom engines can be plugged in the same way.
+
+## Metrics
+
+Prometheus metrics are registered automatically when importing the `dispatch` package. Start the HTTP server to expose them:
+
+```go
+ctx := context.Background()
+go metrics.StartPromServer(ctx, ":2112")
+```
+
+Key metrics:
+- `dispatch_execution_latency_seconds` – histogram of publish-to-ack latency per signal type
+- `vehicles_dispatched_total` – counter of vehicles dispatched per signal type
+- `ack_rate` – gauge representing acknowledged ratio per dispatch
+- `mqtt_publish_success_total` / `mqtt_publish_failure_total` – MQTT publish results
+
+Configure your Prometheus scrape job to target the `/metrics` endpoint.

--- a/core/dispatch/manager_metrics_test.go
+++ b/core/dispatch/manager_metrics_test.go
@@ -1,0 +1,113 @@
+package dispatch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	"github.com/kilianp07/v2g/core/model"
+	"github.com/kilianp07/v2g/infra/logger"
+	"github.com/kilianp07/v2g/infra/mqtt"
+	"github.com/kilianp07/v2g/internal/eventbus"
+)
+
+func TestDispatchMetricsUpdate(t *testing.T) {
+	ResetMetrics(nil)
+	reg := prometheus.NewRegistry()
+	MustRegisterMetrics(reg)
+
+	publisher := mqtt.NewMockPublisher()
+	mgr, err := NewDispatchManager(SimpleVehicleFilter{}, EqualDispatcher{}, NoopFallback{}, publisher, time.Second, nil, nil, nil, logger.NopLogger{}, nil, nil)
+	if err != nil {
+		t.Fatalf("manager: %v", err)
+	}
+
+	v := []model.Vehicle{{ID: "v1", SoC: 0.8, IsV2G: true, Available: true, MaxPower: 10, BatteryKWh: 40}}
+	sig := model.FlexibilitySignal{Type: model.SignalFCR, PowerKW: 5, Duration: time.Second, Timestamp: time.Now()}
+	mgr.Dispatch(sig, v)
+
+	metric := testutil.ToFloat64(vehiclesDispatched.WithLabelValues("FCR"))
+	if metric != 1 {
+		t.Errorf("vehiclesDispatched expected 1 got %f", metric)
+	}
+	if val := testutil.ToFloat64(mqttSuccess); val != 1 {
+		t.Errorf("mqttSuccess expected 1 got %f", val)
+	}
+	if val := testutil.ToFloat64(ackRate.WithLabelValues("FCR")); val != 1 {
+		t.Errorf("ackRate expected 1 got %f", val)
+	}
+	if count := testutil.CollectAndCount(dispatchLatency); count == 0 {
+		t.Errorf("dispatchLatency not updated")
+	}
+}
+
+func TestAckRateCalculation(t *testing.T) {
+	ResetMetrics(nil)
+	reg := prometheus.NewRegistry()
+	MustRegisterMetrics(reg)
+
+	publisher := mqtt.NewMockPublisher()
+	publisher.FailIDs["v2"] = true
+	mgr, err := NewDispatchManager(SimpleVehicleFilter{}, EqualDispatcher{}, NoopFallback{}, publisher, time.Millisecond*10, nil, nil, nil, logger.NopLogger{}, nil, nil)
+	if err != nil {
+		t.Fatalf("manager: %v", err)
+	}
+	vehicles := []model.Vehicle{{ID: "v2", SoC: 0.8, IsV2G: true, Available: true, MaxPower: 10, BatteryKWh: 40}}
+	sig := model.FlexibilitySignal{Type: model.SignalFCR, PowerKW: 5, Duration: time.Second, Timestamp: time.Now()}
+	mgr.Dispatch(sig, vehicles)
+
+	if val := testutil.ToFloat64(ackRate.WithLabelValues("FCR")); val != 0 {
+		t.Errorf("ackRate expected 0 got %f", val)
+	}
+	if val := testutil.ToFloat64(mqttFailure); val != 1 {
+		t.Errorf("mqttFailure expected 1 got %f", val)
+	}
+}
+
+func TestContextParticipation(t *testing.T) {
+	var ctx DispatchContext
+	ctx.SetParticipation("v1", 0.7)
+	if v := ctx.GetParticipation("v1"); v != 0.7 {
+		t.Errorf("unexpected participation %f", v)
+	}
+}
+
+func TestNoopTuner(t *testing.T) {
+	var tuner NoopTuner
+	// should not panic or modify input
+	tuner.Tune([]DispatchResult{})
+}
+
+type dummyDiscovery struct{ closed bool }
+
+func (d *dummyDiscovery) Discover(_ context.Context, _ time.Duration) ([]model.Vehicle, error) {
+	return nil, nil
+}
+
+func (d *dummyDiscovery) Close() error { d.closed = true; return nil }
+
+func TestManagerRunAndClose(t *testing.T) {
+	ResetMetrics(nil)
+	pub := mqtt.NewMockPublisher()
+	bus := eventbus.New()
+	disc := &dummyDiscovery{}
+	mgr, err := NewDispatchManager(SimpleVehicleFilter{}, EqualDispatcher{}, NoopFallback{}, pub, time.Millisecond*10, nil, bus, disc, logger.NopLogger{}, nil, nil)
+	if err != nil {
+		t.Fatalf("manager: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	sigCh := make(chan model.FlexibilitySignal, 1)
+	go mgr.Run(ctx, sigCh)
+	sigCh <- model.FlexibilitySignal{Type: model.SignalFCR, Timestamp: time.Now()}
+	cancel()
+	time.Sleep(10 * time.Millisecond)
+	if err := mgr.Close(); err != nil {
+		t.Fatalf("close error: %v", err)
+	}
+	if !disc.closed {
+		t.Errorf("discovery not closed")
+	}
+}

--- a/core/dispatch/metrics.go
+++ b/core/dispatch/metrics.go
@@ -1,0 +1,99 @@
+package dispatch
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	dispatchLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "dispatch_execution_latency_seconds",
+			Help:    "Latency of dispatch orders from publish to acknowledgment",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"signal_type"},
+	)
+
+	vehiclesDispatched = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "vehicles_dispatched_total",
+			Help: "Number of vehicles dispatched",
+		},
+		[]string{"signal_type"},
+	)
+
+	ackRate = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ack_rate",
+			Help: "Acknowledgment rate for dispatch orders",
+		},
+		[]string{"signal_type"},
+	)
+
+	mqttSuccess = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "mqtt_publish_success_total",
+			Help: "Number of successful MQTT publish operations",
+		},
+	)
+
+	mqttFailure = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "mqtt_publish_failure_total",
+			Help: "Number of failed MQTT publish operations",
+		},
+	)
+)
+
+func init() { MustRegisterMetrics(nil) }
+
+// MustRegisterMetrics registers dispatch metrics on the provided registry.
+// If reg is nil, prometheus.DefaultRegisterer is used.
+func MustRegisterMetrics(reg prometheus.Registerer) {
+	if reg == nil {
+		reg = prometheus.DefaultRegisterer
+	}
+	reg.MustRegister(dispatchLatency, vehiclesDispatched, ackRate, mqttSuccess, mqttFailure)
+}
+
+// ResetMetrics reinitializes metrics collectors for testing purposes and
+// registers them on the provided registry if not nil.
+func ResetMetrics(reg prometheus.Registerer) {
+	dispatchLatency = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "dispatch_execution_latency_seconds",
+			Help:    "Latency of dispatch orders from publish to acknowledgment",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{"signal_type"},
+	)
+	vehiclesDispatched = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "vehicles_dispatched_total",
+			Help: "Number of vehicles dispatched",
+		},
+		[]string{"signal_type"},
+	)
+	ackRate = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "ack_rate",
+			Help: "Acknowledgment rate for dispatch orders",
+		},
+		[]string{"signal_type"},
+	)
+	mqttSuccess = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "mqtt_publish_success_total",
+			Help: "Number of successful MQTT publish operations",
+		},
+	)
+	mqttFailure = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Name: "mqtt_publish_failure_total",
+			Help: "Number of failed MQTT publish operations",
+		},
+	)
+	if reg != nil {
+		MustRegisterMetrics(reg)
+	}
+}

--- a/core/dispatch/metrics_test.go
+++ b/core/dispatch/metrics_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestMetricsRegistration(t *testing.T) {
 	ResetMetrics(nil)
+	t.Cleanup(func() { ResetMetrics(nil) })
 	reg := prometheus.NewRegistry()
 	MustRegisterMetrics(reg)
 	// touch metrics so they are exported

--- a/core/dispatch/metrics_test.go
+++ b/core/dispatch/metrics_test.go
@@ -1,0 +1,39 @@
+package dispatch
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestMetricsRegistration(t *testing.T) {
+	ResetMetrics(nil)
+	reg := prometheus.NewRegistry()
+	MustRegisterMetrics(reg)
+	// touch metrics so they are exported
+	vehiclesDispatched.WithLabelValues("FCR").Inc()
+	dispatchLatency.WithLabelValues("FCR").Observe(0.1)
+	ackRate.WithLabelValues("FCR").Set(1)
+	mqttSuccess.Inc()
+	mqttFailure.Inc()
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	names := map[string]bool{}
+	for _, mf := range mfs {
+		names[*mf.Name] = true
+	}
+	expected := []string{
+		"dispatch_execution_latency_seconds",
+		"vehicles_dispatched_total",
+		"ack_rate",
+		"mqtt_publish_success_total",
+		"mqtt_publish_failure_total",
+	}
+	for _, n := range expected {
+		if !names[n] {
+			t.Errorf("metric %s not registered", n)
+		}
+	}
+}

--- a/test/metrics_integration_test.go
+++ b/test/metrics_integration_test.go
@@ -19,6 +19,7 @@ import (
 
 func TestMetricsHTTPExposure(t *testing.T) {
 	dispatch.ResetMetrics(nil)
+	t.Cleanup(func() { dispatch.ResetMetrics(nil) })
 	reg := prometheus.NewRegistry()
 	dispatch.MustRegisterMetrics(reg)
 

--- a/test/metrics_integration_test.go
+++ b/test/metrics_integration_test.go
@@ -1,0 +1,49 @@
+package test
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/kilianp07/v2g/core/dispatch"
+	"github.com/kilianp07/v2g/core/model"
+	"github.com/kilianp07/v2g/infra/logger"
+	"github.com/kilianp07/v2g/infra/mqtt"
+)
+
+func TestMetricsHTTPExposure(t *testing.T) {
+	dispatch.ResetMetrics(nil)
+	reg := prometheus.NewRegistry()
+	dispatch.MustRegisterMetrics(reg)
+
+	mux := http.NewServeMux()
+	mux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{}))
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	publisher := mqtt.NewMockPublisher()
+	mgr, err := dispatch.NewDispatchManager(dispatch.SimpleVehicleFilter{}, dispatch.EqualDispatcher{}, dispatch.NoopFallback{}, publisher, time.Second, nil, nil, nil, logger.NopLogger{}, nil, nil)
+	if err != nil {
+		t.Fatalf("manager: %v", err)
+	}
+	vehicles := []model.Vehicle{{ID: "v1", SoC: 0.8, IsV2G: true, Available: true, MaxPower: 10, BatteryKWh: 40}}
+	sig := model.FlexibilitySignal{Type: model.SignalFCR, PowerKW: 5, Duration: time.Second, Timestamp: time.Now()}
+	mgr.Dispatch(sig, vehicles)
+
+	resp, err := http.Get(srv.URL + "/metrics")
+	if err != nil {
+		t.Fatalf("get metrics: %v", err)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	out := string(body)
+	if !strings.Contains(out, "vehicles_dispatched_total") {
+		t.Errorf("metrics output missing counter: %s", out)
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic collection and exposure of Prometheus metrics for dispatch operations, including latency, vehicles dispatched, acknowledgment rate, and MQTT publish results.
  * Metrics are now available via an HTTP endpoint for integration with Prometheus monitoring systems.

* **Documentation**
  * Updated the README with instructions for enabling and accessing Prometheus metrics, including endpoint setup and metric descriptions.

* **Tests**
  * Introduced unit and integration tests to verify correct metric updates, acknowledgment calculations, context handling, and HTTP exposure of metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->