### PR TITLE
feat(fleet): add fleet generation with commuter ratio and availability profiles

### DIFF
--- a/simulator/README.md
+++ b/simulator/README.md
@@ -30,6 +30,17 @@ options:
 --influx-bucket InfluxDB bucket
 ```
 
+The schedule file is a JSON object mapping vehicle IDs to RFC3339 departure
+timestamps, for example:
+
+```json
+{
+  "veh0001": "2024-01-01T09:00:00Z",
+  "veh0002": "2024-01-01T12:00:00Z"
+}
+```
+
+
 Each simulated vehicle subscribes to `vehicle/{id}/command` and, according to the
 configured strategy, publishes acknowledgments to `vehicle/{id}/ack`. It
 periodically publishes its SoC on `<prefix>/vehicle/state/{id}` and answers the

--- a/simulator/README.md
+++ b/simulator/README.md
@@ -6,8 +6,14 @@ It can be started with `go run ./simulator` and accepts several command line
 options:
 
 ```
---broker        MQTT broker URL
---count         number of vehicles to simulate
+--broker           MQTT broker URL
+--count            number of vehicles to simulate
+--fleet-size       auto-generate N vehicles
+--commuter-pct     ratio of commuter vehicles (0-1)
+--disconnect-rate  per-minute disconnect probability
+--availability-file hourly availability profile JSON
+--schedule-file    optional schedule overrides
+--template-file    vehicle template overrides
 --ack-latency   fixed latency before sending the ACK (e.g. `200ms`)
 --drop-rate     probability between 0 and 1 to drop an ACK
 --capacity      battery capacity in kWh

--- a/simulator/availability_test.go
+++ b/simulator/availability_test.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	paho "github.com/eclipse/paho.mqtt.golang"
+)
+
+type stubToken struct{ err error }
+
+func (t *stubToken) Wait() bool                       { return true }
+func (t *stubToken) WaitTimeout(d time.Duration) bool { return true }
+func (t *stubToken) Done() <-chan struct{}            { ch := make(chan struct{}); close(ch); return ch }
+func (t *stubToken) Error() error                     { return t.err }
+
+type stubClient struct {
+	mu           sync.Mutex
+	subs         []string
+	pubs         []string
+	disconnected int
+}
+
+func (c *stubClient) IsConnected() bool      { return c.disconnected == 0 }
+func (c *stubClient) IsConnectionOpen() bool { return c.disconnected == 0 }
+func (c *stubClient) Connect() paho.Token    { return &stubToken{} }
+func (c *stubClient) Disconnect(uint)        { c.mu.Lock(); c.disconnected++; c.mu.Unlock() }
+func (c *stubClient) Publish(topic string, qos byte, retained bool, payload interface{}) paho.Token {
+	c.mu.Lock()
+	c.pubs = append(c.pubs, topic)
+	c.mu.Unlock()
+	return &stubToken{}
+}
+func (c *stubClient) Subscribe(topic string, qos byte, cb paho.MessageHandler) paho.Token {
+	c.mu.Lock()
+	c.subs = append(c.subs, topic)
+	c.mu.Unlock()
+	return &stubToken{}
+}
+func (c *stubClient) SubscribeMultiple(map[string]byte, paho.MessageHandler) paho.Token {
+	return &stubToken{}
+}
+func (c *stubClient) Unsubscribe(...string) paho.Token        { return &stubToken{} }
+func (c *stubClient) AddRoute(string, paho.MessageHandler)    {}
+func (c *stubClient) OptionsReader() paho.ClientOptionsReader { return paho.ClientOptionsReader{} }
+
+func TestHandleAvailabilityConnect(t *testing.T) {
+	rng = rand.New(rand.NewSource(1))
+	sc := &stubClient{}
+	mqttClientFactory = func(b, c string) (paho.Client, error) { return sc, nil }
+	defer func() { mqttClientFactory = realMQTTClient }()
+
+	var prof [24]float64
+	prof[time.Now().Hour()] = 1
+	v := &SimulatedVehicle{
+		ID:           "veh1",
+		Broker:       "tcp://localhost:1883",
+		TopicPrefix:  "test",
+		Availability: prof,
+	}
+	v.handleAvailabilityTick(context.Background())
+	if v.client == nil {
+		t.Fatalf("expected client to be set")
+	}
+	if len(sc.subs) != 2 {
+		t.Fatalf("expected 2 subscriptions got %d", len(sc.subs))
+	}
+}
+
+func TestHandleAvailabilityDisconnect(t *testing.T) {
+	rng = rand.New(rand.NewSource(1))
+	sc := &stubClient{}
+	mqttClientFactory = func(b, c string) (paho.Client, error) { return sc, nil }
+	defer func() { mqttClientFactory = realMQTTClient }()
+
+	v := &SimulatedVehicle{
+		ID:             "veh1",
+		Broker:         "tcp://localhost:1883",
+		TopicPrefix:    "test",
+		DisconnectRate: 1,
+		client:         sc,
+	}
+	v.handleAvailabilityTick(context.Background())
+	if v.client != nil {
+		t.Fatalf("expected client to be cleared")
+	}
+	if sc.disconnected == 0 {
+		t.Fatalf("expected disconnect to be called")
+	}
+}

--- a/simulator/config.go
+++ b/simulator/config.go
@@ -9,13 +9,20 @@ import (
 type Config struct {
 	Broker          string
 	Count           int
+	FleetSize       int
 	AckLatency      time.Duration
 	DropRate        float64
+	DisconnectRate  float64
 	CapacityKWh     float64
 	ChargeRateKW    float64
 	DischargeRateKW float64
 	MaxPower        float64
 	Interval        time.Duration
+
+	CommuterPct      float64
+	AvailabilityFile string
+	ScheduleFile     string
+	TemplateFile     string
 
 	BatteryProfile string
 	Verbose        bool
@@ -32,11 +39,17 @@ func (c Config) Validate() error {
 	if c.Broker == "" {
 		return fmt.Errorf("broker is required")
 	}
-	if c.Count <= 0 {
-		return fmt.Errorf("count must be positive")
+	if c.FleetSize == 0 {
+		c.FleetSize = c.Count
+	}
+	if c.FleetSize <= 0 {
+		return fmt.Errorf("fleet-size must be positive")
 	}
 	if c.DropRate < 0 || c.DropRate > 1 {
 		return fmt.Errorf("drop-rate must be between 0 and 1")
+	}
+	if c.DisconnectRate < 0 || c.DisconnectRate > 1 {
+		return fmt.Errorf("disconnect-rate must be between 0 and 1")
 	}
 	if c.CapacityKWh <= 0 {
 		return fmt.Errorf("capacity must be positive")
@@ -49,6 +62,9 @@ func (c Config) Validate() error {
 	}
 	if c.Interval <= 0 {
 		return fmt.Errorf("interval must be positive")
+	}
+	if c.CommuterPct < 0 || c.CommuterPct > 1 {
+		return fmt.Errorf("commuter percentage must be between 0 and 1")
 	}
 	return nil
 }

--- a/simulator/config.go
+++ b/simulator/config.go
@@ -35,7 +35,7 @@ type Config struct {
 	InfluxBucket string
 }
 
-func (c Config) Validate() error {
+func (c *Config) Validate() error {
 	if c.Broker == "" {
 		return fmt.Errorf("broker is required")
 	}

--- a/simulator/fleet.go
+++ b/simulator/fleet.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+var fleetRng = rand.New(rand.NewSource(time.Now().UnixNano()))
+
+// FleetConfig holds parameters for bulk fleet generation.
+type FleetConfig struct {
+	Size           int
+	CommuterPct    float64
+	DisconnectRate float64
+	Availability   [24]float64
+	Schedule       map[string]time.Time
+}
+
+// VehicleTemplate allows overriding generated vehicles.
+type VehicleTemplate struct {
+	Departure string `json:"departure"`
+}
+
+// GenerateFleet creates Size vehicles with IDs veh0001..vehNNNN.
+// Vehicles are assigned the "commuter" segment according to CommuterPct,
+// otherwise "opportunistic".
+func GenerateFleet(cfg FleetConfig, tmpl map[string]VehicleTemplate) []SimulatedVehicle {
+	if cfg.Size <= 0 {
+		return nil
+	}
+	vs := make([]SimulatedVehicle, cfg.Size)
+	for i := 0; i < cfg.Size; i++ {
+		id := fmt.Sprintf("veh%04d", i+1)
+		seg := "opportunistic"
+		if cfg.CommuterPct > 0 && fleetRng.Float64() < cfg.CommuterPct {
+			seg = "commuter"
+		}
+		dep := time.Time{}
+		if t, ok := cfg.Schedule[id]; ok {
+			dep = t
+		} else if tmpl != nil {
+			if v, ok := tmpl[id]; ok {
+				if v.Departure != "" {
+					if tt, err := time.Parse(time.RFC3339, v.Departure); err == nil {
+						dep = tt
+					}
+				}
+			}
+		}
+		vs[i] = SimulatedVehicle{
+			ID:             id,
+			Segment:        seg,
+			DisconnectRate: cfg.DisconnectRate,
+			Availability:   cfg.Availability,
+			Departure:      dep,
+		}
+	}
+	return vs
+}
+
+// LoadAvailabilityProfile reads a hourly availability profile from JSON or YAML.
+func LoadAvailabilityProfile(data []byte) ([24]float64, error) {
+	var m map[string]float64
+	var prof [24]float64
+	if err := json.Unmarshal(data, &m); err != nil {
+		return prof, err
+	}
+	for h, v := range m {
+		var hour int
+		if _, err := fmt.Sscanf(h, "%d", &hour); err != nil {
+			continue
+		}
+		if hour >= 0 && hour < 24 {
+			prof[hour] = v
+		}
+	}
+	return prof, nil
+}

--- a/simulator/fleet.go
+++ b/simulator/fleet.go
@@ -23,7 +23,7 @@ type VehicleTemplate struct {
 	Departure string `json:"departure"`
 }
 
-// GenerateFleet creates Size vehicles with IDs veh0001..vehNNNN.
+// GenerateFleet creates Size vehicles with IDs veh001..vehNNN.
 // Vehicles are assigned the "commuter" segment according to CommuterPct,
 // otherwise "opportunistic".
 func GenerateFleet(cfg FleetConfig, tmpl map[string]VehicleTemplate) []SimulatedVehicle {
@@ -32,7 +32,7 @@ func GenerateFleet(cfg FleetConfig, tmpl map[string]VehicleTemplate) []Simulated
 	}
 	vs := make([]SimulatedVehicle, cfg.Size)
 	for i := 0; i < cfg.Size; i++ {
-		id := fmt.Sprintf("veh%04d", i+1)
+		id := fmt.Sprintf("veh%03d", i+1)
 		seg := "opportunistic"
 		if cfg.CommuterPct > 0 && fleetRng.Float64() < cfg.CommuterPct {
 			seg = "commuter"
@@ -51,10 +51,12 @@ func GenerateFleet(cfg FleetConfig, tmpl map[string]VehicleTemplate) []Simulated
 		}
 		vs[i] = SimulatedVehicle{
 			ID:             id,
+			IsV2G:          true,
 			Segment:        seg,
 			DisconnectRate: cfg.DisconnectRate,
 			Availability:   cfg.Availability,
 			Departure:      dep,
+			ackCh:          make(chan command, 50),
 		}
 	}
 	return vs

--- a/simulator/fleet_test.go
+++ b/simulator/fleet_test.go
@@ -13,7 +13,7 @@ func TestGenerateFleetCount(t *testing.T) {
 	if len(vs) != 5 {
 		t.Fatalf("expected 5 vehicles, got %d", len(vs))
 	}
-	if vs[0].ID != "veh0001" || vs[4].ID != "veh0005" {
+	if vs[0].ID != "veh001" || vs[4].ID != "veh005" {
 		t.Fatalf("unexpected ids %s %s", vs[0].ID, vs[4].ID)
 	}
 }
@@ -52,7 +52,7 @@ func TestLoadAvailabilityError(t *testing.T) {
 }
 
 func TestScheduleOverride(t *testing.T) {
-	cfg := FleetConfig{Size: 1, Schedule: map[string]time.Time{"veh0001": time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)}}
+	cfg := FleetConfig{Size: 1, Schedule: map[string]time.Time{"veh001": time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)}}
 	vs := GenerateFleet(cfg, nil)
 	if vs[0].Departure.IsZero() {
 		t.Fatal("departure not set")
@@ -61,7 +61,7 @@ func TestScheduleOverride(t *testing.T) {
 
 func TestTemplateOverride(t *testing.T) {
 	tmpl := map[string]VehicleTemplate{
-		"veh0002": {Departure: "2024-01-01T09:00:00Z"},
+		"veh002": {Departure: "2024-01-01T09:00:00Z"},
 	}
 	cfg := FleetConfig{Size: 3}
 	vs := GenerateFleet(cfg, tmpl)

--- a/simulator/fleet_test.go
+++ b/simulator/fleet_test.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+)
+
+func TestGenerateFleetCount(t *testing.T) {
+	fleetRng = rand.New(rand.NewSource(1))
+	cfg := FleetConfig{Size: 5}
+	vs := GenerateFleet(cfg, nil)
+	if len(vs) != 5 {
+		t.Fatalf("expected 5 vehicles, got %d", len(vs))
+	}
+	if vs[0].ID != "veh0001" || vs[4].ID != "veh0005" {
+		t.Fatalf("unexpected ids %s %s", vs[0].ID, vs[4].ID)
+	}
+}
+
+func TestDistribution(t *testing.T) {
+	fleetRng = rand.New(rand.NewSource(1))
+	cfg := FleetConfig{Size: 100, CommuterPct: 0.6}
+	vs := GenerateFleet(cfg, nil)
+	commuters := 0
+	for i := range vs {
+		if vs[i].Segment == "commuter" {
+			commuters++
+		}
+	}
+	if commuters < 40 || commuters > 80 {
+		t.Fatalf("commuter ratio unexpected: %d", commuters)
+	}
+}
+
+func TestLoadAvailability(t *testing.T) {
+	data := []byte(`{"0":0.1,"1":0.2,"2":0.3}`)
+	prof, err := LoadAvailabilityProfile(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if prof[2] != 0.3 {
+		t.Fatalf("expected 0.3 got %f", prof[2])
+	}
+}
+
+func TestLoadAvailabilityError(t *testing.T) {
+	_, err := LoadAvailabilityProfile([]byte(`invalid`))
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestScheduleOverride(t *testing.T) {
+	cfg := FleetConfig{Size: 1, Schedule: map[string]time.Time{"veh0001": time.Date(2024, 1, 1, 10, 0, 0, 0, time.UTC)}}
+	vs := GenerateFleet(cfg, nil)
+	if vs[0].Departure.IsZero() {
+		t.Fatal("departure not set")
+	}
+}
+
+func TestTemplateOverride(t *testing.T) {
+	tmpl := map[string]VehicleTemplate{
+		"veh0002": {Departure: "2024-01-01T09:00:00Z"},
+	}
+	cfg := FleetConfig{Size: 3}
+	vs := GenerateFleet(cfg, tmpl)
+	if vs[1].Departure.IsZero() {
+		t.Fatal("template departure not applied")
+	}
+}

--- a/simulator/main.go
+++ b/simulator/main.go
@@ -19,7 +19,7 @@ import (
 
 func main() {
 	cfg := parseFlags()
-	if err := cfg.Validate(); err != nil {
+	if err := (&cfg).Validate(); err != nil {
 		log.Fatalf("invalid config: %v", err)
 	}
 
@@ -57,6 +57,10 @@ func main() {
 		prof, err = readAvailabilityFile(cfg.AvailabilityFile)
 		if err != nil {
 			log.Fatalf("availability file: %v", err)
+		}
+	} else {
+		for i := range prof {
+			prof[i] = 1
 		}
 	}
 

--- a/simulator/mqtt_sim.go
+++ b/simulator/mqtt_sim.go
@@ -7,7 +7,15 @@ import (
 	paho "github.com/eclipse/paho.mqtt.golang"
 )
 
+// mqttClientFactory is used to create MQTT clients. It can be swapped out in
+// tests.
+var mqttClientFactory = realMQTTClient
+
 func newMQTTClient(broker, clientID string) (paho.Client, error) {
+	return mqttClientFactory(broker, clientID)
+}
+
+func realMQTTClient(broker, clientID string) (paho.Client, error) {
 	if broker == "" || clientID == "" {
 		return nil, fmt.Errorf("broker and clientID must be provided")
 	}

--- a/test/simulator_integration_test.go
+++ b/test/simulator_integration_test.go
@@ -170,7 +170,7 @@ func TestSimulatorAndDispatcherIntegration(t *testing.T) {
 		Duration:  time.Minute,
 		Timestamp: time.Now(),
 	}
-	res := mgr.Dispatch(sig, nil)
+	res := mgr.Dispatch(sig, vehicles)
 	if len(res.Errors) > 0 {
 		t.Fatalf("dispatch errors: %v", res.Errors)
 	}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for generating a customizable fleet of simulated vehicles, including options for fleet size, commuter percentage, disconnect rate, and vehicle templates.
  * Vehicles now simulate intermittent connectivity and availability based on hourly profiles, random disconnect rates, and scheduled departures.
  * New command-line options and JSON file inputs allow users to configure fleet behavior, availability profiles, schedules, and vehicle templates.

* **Documentation**
  * Expanded and updated simulator documentation to include new command-line options for enhanced fleet configuration.

* **Tests**
  * Introduced unit tests to verify fleet generation, availability profile loading, and schedule/template overrides.
  * Added tests for simulated vehicle availability handling, including connection and disconnection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->