### PR TITLE
feat(metrics): enrich InfluxDB metrics with dispatch order and acknowledgment tracking

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -1,0 +1,19 @@
+# Metrics
+
+The service writes the following InfluxDB measurements:
+
+- **vehicle_state**
+  - tags: `vehicle_id`
+  - fields: `soc` (float), `status` (string), `power_kw` (float)
+- **dispatch_order**
+  - tags: `vehicle_id`, `signal_type`, `order_id`
+  - fields: `power_kw` (float), `score` (float), `accepted` (bool)
+- **acknowledgment**
+  - tags: `vehicle_id`, `order_id`
+  - fields: `ack` (bool), `latency_ms` (float)
+- **signal**
+  - tags: `signal_type`
+  - fields: `power_requested_kw` (float), `duration_s` (int)
+
+Run the application with `--demo-seed` to write sample points and verify
+connectivity.

--- a/core/events/ack.go
+++ b/core/events/ack.go
@@ -8,6 +8,8 @@ import (
 
 // AckEvent is published for each vehicle acknowledgment or error.
 type AckEvent struct {
+	// OrderID identifies the dispatch order associated with this ACK.
+	OrderID      string
 	VehicleID    string
 	Signal       model.SignalType
 	Acknowledged bool

--- a/core/metrics/metrics.go
+++ b/core/metrics/metrics.go
@@ -52,13 +52,15 @@ type VehicleStateRecorder interface {
 }
 
 // DispatchOrderEvent represents a command sent to a vehicle.
+// DispatchOrderEvent represents a command sent to a vehicle.
 type DispatchOrderEvent struct {
-	DispatchID  string
+	OrderID     string
 	VehicleID   string
 	Signal      model.SignalType
 	PowerKW     float64
 	Score       float64
 	MarketPrice float64
+	Accepted    bool
 	Time        time.Time
 }
 
@@ -68,8 +70,9 @@ type DispatchOrderRecorder interface {
 }
 
 // DispatchAckEvent captures the acknowledgment for an order.
+// DispatchAckEvent captures the acknowledgment for an order.
 type DispatchAckEvent struct {
-	DispatchID   string
+	OrderID      string
 	VehicleID    string
 	Signal       model.SignalType
 	Acknowledged bool

--- a/infra/metrics/collector.go
+++ b/infra/metrics/collector.go
@@ -2,7 +2,6 @@ package metrics
 
 import (
 	"context"
-	"strconv"
 	"time"
 
 	"github.com/kilianp07/v2g/core/events"
@@ -39,12 +38,12 @@ func StartEventCollector(ctx context.Context, bus eventbus.EventBus, sink coreme
 							errStr = e.Err.Error()
 						}
 						_ = r.RecordDispatchAck(coremetrics.DispatchAckEvent{
+							OrderID:      e.OrderID,
 							VehicleID:    e.VehicleID,
 							Signal:       e.Signal,
 							Acknowledged: e.Acknowledged,
 							Latency:      e.Latency,
 							Error:        errStr,
-							DispatchID:   strconv.FormatInt(time.Now().UnixNano(), 10),
 							Time:         time.Now(),
 						})
 					}

--- a/simulator/vehicle.go
+++ b/simulator/vehicle.go
@@ -123,11 +123,12 @@ func (v *SimulatedVehicle) onCommand(ctx context.Context) func(paho.Client, paho
 		allowed := v.applyPowerOrder(m.PowerKW)
 		if rec, ok := v.Metrics.(metrics.DispatchOrderRecorder); ok {
 			_ = rec.RecordDispatchOrder(metrics.DispatchOrderEvent{
-				DispatchID: m.CommandID,
-				VehicleID:  v.ID,
-				Signal:     model.SignalFCR,
-				PowerKW:    allowed,
-				Time:       now,
+				OrderID:   m.CommandID,
+				VehicleID: v.ID,
+				Signal:    model.SignalFCR,
+				PowerKW:   allowed,
+				Accepted:  true,
+				Time:      now,
 			})
 		}
 		cmd := command{id: m.CommandID, power: allowed, received: now}
@@ -180,7 +181,7 @@ func (v *SimulatedVehicle) worker(ctx context.Context) {
 			sent := v.Strategy.Ack(ctx, v.client, v.ID, cmd.id)
 			if rec, ok := v.Metrics.(metrics.DispatchAckRecorder); ok {
 				_ = rec.RecordDispatchAck(metrics.DispatchAckEvent{
-					DispatchID:   cmd.id,
+					OrderID:      cmd.id,
 					VehicleID:    v.ID,
 					Signal:       model.SignalFCR,
 					Acknowledged: sent,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added --demo-seed mode to generate sample InfluxDB metrics and exit.
  - Enabled automatic metrics event collection when metrics are configured.

- Metrics
  - Revamped InfluxDB schema: vehicle_state, dispatch_order, acknowledgment, and signal measurements.
  - Standardized tags/fields: order_id, ack, power_requested_kw, duration_s; added accepted.
  - Derived vehicle status (unavailable/idle/charging); removed deprecated fields/tags and extra points.
  - Acknowledgments and orders now correlate via order_id.

- Documentation
  - Added METRICS.md describing all measurements and how to run the demo seed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->